### PR TITLE
Tone down logging of "lock held" messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,5 +59,8 @@ SHELL ["/busybox/sh", "-c"]
 COPY --from=hostname-builder /usr/bin/${TARGETPLATFORM}/hostname /app/hostname
 COPY --from=elector-builder /usr/bin/${TARGETPLATFORM}/leader-elector /app/server
 
+# Limit continuous logging of the lease on INFO level
+ENV GLOG_vmodule="leaderelection=3"
+
 USER 1001
 ENTRYPOINT /app/server --id=$(/app/hostname) $@

--- a/election/example/main.go
+++ b/election/example/main.go
@@ -112,7 +112,7 @@ func main() {
 
 	fn := func(str string) {
 		leader.Name = str
-		fmt.Printf("%s is the leader\n", leader.Name)
+		glog.V(3).Infof("%s is the leader\n", leader.Name)
 	}
 
 	e, err := election.NewElection(*name, *id, *namespace, *ttl, fn, kubeClient)

--- a/election/vendor/k8s.io/kubernetes/pkg/client/leaderelection/leaderelection.go
+++ b/election/vendor/k8s.io/kubernetes/pkg/client/leaderelection/leaderelection.go
@@ -293,7 +293,7 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 		}
 		if le.observedTime.Add(le.config.LeaseDuration).After(now.Time) &&
 			oldLeaderElectionRecord.HolderIdentity != le.config.Identity {
-			glog.Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
+			glog.V(2).Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
 			return false
 		}
 	}


### PR DESCRIPTION
The leader elector is constantly logging "lock held..." messages that
spam the logs. In a later version of the leader elector library this is
updated with a log level. But that requires updating many libraries.

Instead update the specific log line directly and add the default level
to the `Dockerfile` which customers could always override.