### PR TITLE
Args were not expanded correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,13 @@ ARG TARGETPLATFORM='linux/amd64'
 
 MAINTAINER Instana Engineering <support@instana.com>
 
-# Docker defaults to /bin/sh need to override to use busybox shell.
-SHELL ["/busybox/sh", "-c"]
-
 COPY --from=hostname-builder /usr/bin/${TARGETPLATFORM}/hostname /app/hostname
 COPY --from=elector-builder /usr/bin/${TARGETPLATFORM}/leader-elector /app/server
+
+COPY start.sh /
 
 # Limit continuous logging of the lease on INFO level
 ENV GLOG_vmodule="leaderelection=3"
 
 USER 1001
-ENTRYPOINT /app/server --id=$(/app/hostname) $@
+ENTRYPOINT ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/busybox/sh
+/app/server --id=$(/app/hostname) "$@"
+


### PR DESCRIPTION
I am not sure how it actually works in your env, but I couldn't get this to work at all.

I get `--election cannot be empty` error every time, I guess you need to override completely the `ENTRYPOINT`, which is sad.

This patch uses a more standard approach through a shell script, and use `ENTRYPOINT` only since `SHELL` is not OCI-compatible.

Now you can do `docker run learder-elector --election=test` without getting an error.